### PR TITLE
Connect to WebOS via WSS protocol

### DIFF
--- a/interface/index.ts
+++ b/interface/index.ts
@@ -36,10 +36,20 @@ producer.connect().then(() => logger.info('Connected to Message Queue.'));
 
 // LG WebOS Stuff
 export const ipAddress: string = config.tvIpAddress;
-export const connectionUrl: string = `ws://${ipAddress}:3000`;
+export const connectionUrl: string = `wss://${ipAddress}:3001`;
 export const connectionConfig: Config = {
   url: connectionUrl,
   timeout: 30_000,
+  // @ts-ignore
+  wsconfig: {
+    keepalive: true,
+    keepaliveInterval: 10000,
+    dropConnectionOnKeepaliveTimeout: true,
+    keepaliveGracePeriod: 5000,
+    tlsOptions: {
+      rejectUnauthorized: false
+    }
+  }
 };
 
 export let connection = lgtv(connectionConfig);


### PR DESCRIPTION
**This pull request includes the following changes:**
- Connection to WebOS is being established **via the WSS protocol** instead of the WS protocol so that the **communication is being encrypted via TLS**
- A **custom WS configuration is being set** when initiating the LGTV instance (@ts-ignore must be used as the library's type definitions are not actually including these options even though they are being picked up)
  - The primary reason that we have to include this is because the interface has to accept WebOS's self-signed certificates in order to being able to connect