### PR TITLE
Allow IDE Block

### DIFF
--- a/.github/blocks/config.json
+++ b/.github/blocks/config.json
@@ -1,0 +1,9 @@
+{
+  "allow": [
+    {
+      "owner": "Krzysztof-Cieslak",
+      "repo": "IDE-Block",
+      "id": "ide-block"
+    }
+  ]
+}


### PR DESCRIPTION
Allows the usage of the IDE Block on GitHub Next.